### PR TITLE
Added any support from css-what, so that the operator '*=' (includes/contains) is allowed.

### DIFF
--- a/src/vcss.ts
+++ b/src/vcss.ts
@@ -69,6 +69,11 @@ export function matchSelector(
             if (debug)
               log('Attribute exists', success)
           }
+          else if(action === 'any') {
+            success = !!element.getAttribute(name)?.includes(value)
+            if (debug)
+              console.log("Attribute any", success);
+          }
           else {
             console.warn('Unknown CSS selector action', action)
           }


### PR DESCRIPTION
I noticed that the any action from css-what was not present so when matching `a[href]:not([href *= "javascript:" i])` or `iframe[src*=domain.tdl]` it would print out a warn of "Unknown CSS selector action" as the any operator was not implemented for the attributes in the parser.

Example:
``` js
var zeedDom = require("zeed-dom");

const dom = zeedDom.vdom("<div>Hello World<a href=\"javascript:SomeValues\">Test</a></div>");

const elements = dom.querySelectorAll("a[href]:not([href *= \"javascript:\" i])");
```
The var elements will contain the `<a>` element but the expected result should be an empty array `[]`

This PR adds support to the any attribute action to allow the above mention of selector to be used.