### PR TITLE
Fix infinite loop in `HtmlParser`

### DIFF
--- a/src/htmlparser.spec.ts
+++ b/src/htmlparser.spec.ts
@@ -115,6 +115,11 @@ $('body')
       '<<<',
       '<<div',
       '<div<div',
+      '>',
+      '>>',
+      '>>>',
+      '>>div',
+      '>div>div',
     ]
 
     for (const t of tests) {

--- a/src/htmlparser.spec.ts
+++ b/src/htmlparser.spec.ts
@@ -8,8 +8,8 @@ describe("htmlparser", () => {
     <title>Test</title>
     </head>
     <body>
-    <pre><code class="lang-jsx">               
-      <span class="hljs-tag">&lt;/<span class="hljs-name">a</span>&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-name">li</span>&gt;</span>)}    
+    <pre><code class="lang-jsx">
+      <span class="hljs-tag">&lt;/<span class="hljs-name">a</span>&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-name">li</span>&gt;</span>)}
     </code></pre>
     </body>
     </html>`
@@ -106,5 +106,20 @@ $('body')
       })
       </script>"
     `)
+  })
+
+  it("should not recurse on bad fragment", () => {
+    const tests = [
+      '<',
+      '<<',
+      '<<<',
+      '<<div',
+      '<div<div',
+    ]
+
+    for (const t of tests) {
+      const { textContent: text } = parseHTML(t) as VHTMLDocument
+      expect(text).toEqual(t)
+    }
   })
 })

--- a/src/htmlparser.ts
+++ b/src/htmlparser.ts
@@ -81,10 +81,13 @@ export class HtmlParser {
 
       if (treatAsChars) {
         index = html.indexOf('<')
+        let offset = index
 
         if (index === 0) {
           // First char is a < so find the next one
           index = html.substring(1).indexOf('<')
+          // We're at substring(1) so add 1 to the index
+          offset = offset + 1
         }
 
         if (index === -1) {
@@ -92,8 +95,8 @@ export class HtmlParser {
           html = ''
         }
         else {
-          characters = html.substring(0, index)
-          html = html.substring(index)
+          characters = html.substring(0, offset)
+          html = html.substring(offset)
         }
 
         if (!this.options.ignoreWhitespaceText || !/^\s*$/.test(characters))


### PR DESCRIPTION
We're integrating Tiptap, which relies on this library, and noticed that trying to [generateJSON](https://github.com/ueberdosis/tiptap/blob/develop/packages/html/src/generateJSON.ts#L7) from a text fragment `<<` results in an infinite loop which[ crashes the browser](https://github.com/bluesky-social/social-app/issues/1654).

This PR fixes what I think is a small bug, where the string slicing was off-by-one due to the `substring(1)` call.