### PR TITLE
Fix: `children` should return only elements

### DIFF
--- a/src/serialize-markdown.ts
+++ b/src/serialize-markdown.ts
@@ -12,13 +12,13 @@ function serialize(node: VNode | VElement, context: SerializeContext = {
   count: 0,
 }): string {
   if (node.nodeType === VNode.DOCUMENT_FRAGMENT_NODE) {
-    return node.children.map(c => serialize(c, { ...context })).join('')
+    return node.childNodes.map(c => serialize(c, { ...context })).join('')
   }
 
   else if (isVElement(node)) {
     const tag: string = node.tagName.toLowerCase()
 
-    const handleChildren = (ctx?: Partial<SerializeContext>): string => node.children.map(c => serialize(c, { ...context, ...ctx })).join('')
+    const handleChildren = (ctx?: Partial<SerializeContext>): string => node.childNodes.map(c => serialize(c, { ...context, ...ctx })).join('')
 
     const rules: Record<string, () => string> = {
       b: () => `**${handleChildren()}**`,

--- a/src/serialize-plaintext.ts
+++ b/src/serialize-plaintext.ts
@@ -13,13 +13,13 @@ function serialize(node: VNode | VElement, context: SerializeContext = {
   count: 0,
 }): string {
   if (node.nodeType === VNode.DOCUMENT_FRAGMENT_NODE) {
-    return node.children.map(c => serialize(c, { ...context })).join('')
+    return node.childNodes.map(c => serialize(c, { ...context })).join('')
   }
 
   else if (isVElement(node)) {
     const tag: string = node.tagName.toLowerCase()
 
-    const handleChildren = (ctx?: Partial<SerializeContext>): string => node.children.map(c => serialize(c, { ...context, ...ctx })).join('')
+    const handleChildren = (ctx?: Partial<SerializeContext>): string => node.childNodes.map(c => serialize(c, { ...context, ...ctx })).join('')
 
     const rules: Record<string, () => string> = {
       br: () => `${handleChildren()}\n`,

--- a/src/serialize-safehtml.ts
+++ b/src/serialize-safehtml.ts
@@ -15,12 +15,12 @@ function serialize(node: VNode, context: SerializeContext = {
   count: 0,
 }): string {
   if (node.nodeType === VNode.DOCUMENT_FRAGMENT_NODE) {
-    return node.children.map(c => serialize(c, { ...context })).join('')
+    return node.childNodes.map(c => serialize(c, { ...context })).join('')
   }
 
   else if (isVElement(node)) {
     const tag: string = node.tagName?.toLowerCase()
-    const handleChildren = (ctx?: Partial<SerializeContext>): string => node.children.map(c => serialize(c, { ...context, ...ctx })).join('')
+    const handleChildren = (ctx?: Partial<SerializeContext>): string => node.childNodes.map(c => serialize(c, { ...context, ...ctx })).join('')
 
     const rules: Record<string, () => string> = {
       a: () => `<a href="${escapeHTML(node.getAttribute('href') ?? '')}" rel="noopener noreferrer" target="_blank">${handleChildren()}</a>`,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,7 +10,7 @@ export function removeBodyContainer(body: VNodeQuery): VNodeQuery {
       body.appendChild(ehead.childNodes)
     }
     if (ebody) {
-      body.appendChild(ebody.children)
+      body.appendChild(ebody.childNodes)
     }
     return body
   }

--- a/src/vdom.spec.tsx
+++ b/src/vdom.spec.tsx
@@ -288,4 +288,10 @@ describe('vDOM', () => {
     el.setTagName('main')
     expect(el.render()).toBe('<main>Hello</main>')
   })
+
+  it('should include only elements in children', () => {
+    const el: VElement = parseHTML('<div> <p>Hello</p> </div>').firstChild
+    expect(el.childNodes).toHaveLength(3)
+    expect(el.children).toHaveLength(1)
+  })
 })

--- a/src/vdom.ts
+++ b/src/vdom.ts
@@ -187,7 +187,7 @@ export class VNode {
   }
 
   get children() {
-    return this._childNodes || []
+    return (this._childNodes || []).filter<any>(isVElement)
   }
 
   get firstChild() {


### PR DESCRIPTION
`VNode.children` was incorrectly configured to return the same as `VNode.childNodes`, whereas it should actually return only elements according to the spec. https://developer.mozilla.org/en-US/docs/Web/API/Element/children

When I fixed this, it caused a number of test failures because various helper functions were using `children` when they actually meant `childNodes`. I've fixed all of those that I could find, and the tests now pass, but there may be some I missed. In particular, I wasn't sure whether to change `tag.children` in `hArgumentParser` since `tag` has type `any` and may or may not be a VNode.

In the new implementation of `VNode.children`, I used `filter<any>(isVElement)`. The reason for the `<any>` is because without it, the return type becomes `VElement[]`, which would make `VNode.children` the only children-related property that doesn't return `any[]`. I'm not sure why `_childNodes` is typed as `any[]`, but I thought it best to keep it consistent for now.